### PR TITLE
Feature/update restapi tests

### DIFF
--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -32,9 +32,9 @@ def test_get_bib(session):
     bib_id = create_bib(session)
 
     expected_record_location = bib_id
-    expected_content_location = "{0}/data.jsonld".format(bib_id)
-    expected_document_header = "{0}".format(bib_id)
-    expected_link_header = "<{0}>; rel=describedby".format(bib_id)
+    expected_content_location = f"{bib_id}/data.jsonld"
+    expected_document_header = f"{bib_id}"
+    expected_link_header = f"<{bib_id}>; rel=describedby"
 
     result = session.get(bib_id)
     assert result.status_code == 200

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -930,6 +930,14 @@ def test_search_or_prefix(session):
     assert (len(deduplicated_a_and_b) == len(es_result_a_or_b['items']))
 
 
+def test_get_catalogue_start_page(session):
+    result = requests.get(ROOT_URL + "/katalogisering", headers={
+        'Accept': "text/html, */*;q=0.9",
+    })
+    assert result.status_code == 200
+    assert result.headers['Content-Type'].startswith('text/html')
+
+
 def has_reference(x, ref, key=None):
     if isinstance(x, dict):
         return any([has_reference(x[key], ref, key=key) for key in x])

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -361,6 +361,33 @@ def test_get_with_lens(session, view, lens):
     assert check_lens(json) == lens
 
 
+def test_content_negotiation(session):
+    bib_id = UNIQUE_INSTANCE_RECORD_ID
+
+    result = session.get(bib_id, headers={'Accept': "text/turtle"})
+
+    assert result.status_code == 200
+    assert result.headers['Content-Type'] == 'text/turtle;charset=UTF-8'
+
+    assert b'prefix : <' in result.content
+
+
+def test_profile_negotiation(session):
+    bib_id = UNIQUE_INSTANCE_RECORD_ID
+
+    profile_uri = 'https://id.kb.se/sys/context/target/loc-w3c-sdo'
+    result = session.get(bib_id, headers={
+        'Accept': "text/turtle",
+        'Accept-Profile': f"<{profile_uri}>"
+    })
+
+    assert result.status_code == 200
+    assert result.headers['Content-Type'] == 'text/turtle;charset=UTF-8'
+    assert profile_uri in result.headers['Content-Profile']
+
+    assert b'prefix bf2: <' in result.content
+
+
 def test_search(session):
     search_endpoint = "/find"
     limit = 1


### PR DESCRIPTION
The profile negotiation fails since the POST:ed `@context` reference is *stored* in LDDB (rather than checked and removed). Will look into that as part of on-store normalization and better contracts (prior to &mdash; or instead of &mdash; editing test data in this repository).